### PR TITLE
Fixed issue where the user couldn't uninstall the addin

### DIFF
--- a/mySampleWiXSetupCA/RegistryAbstractor.cs
+++ b/mySampleWiXSetupCA/RegistryAbstractor.cs
@@ -63,8 +63,8 @@ namespace mySampleWiXSetupCA
 
         public void DeleteHkcuKey(string subKey)
         {
-            _session.Log("Start the delevetion of  HKCU sub key " + subKey);
-            _baseRegistryHkcu.DeleteSubKey(subKey);
+            _session.Log("Start the deletion of HKCU sub key " + subKey);
+            _baseRegistryHkcu.DeleteSubKey(subKey, false);
         }
     }
 }


### PR DESCRIPTION
Fixed issue where the user couldn't uninstall the addin if the active setup hkcu does not exists. If the key does not exists, just skip the deletion instead of throwing an exception which stop the uninstall process.

Also fix spelling issue in log (deletion instead of delevetion).