### PR TITLE
Added support for spaces in path to XLL, and Excel 2016

### DIFF
--- a/mySampleWiXSetup/mySampleSetup.wxs
+++ b/mySampleWiXSetup/mySampleSetup.wxs
@@ -69,14 +69,18 @@
       <RegistrySearch Id="OfficeExcel2013InstallPath64" Root="HKLM" Key="SOFTWARE\Microsoft\Office\15.0\Excel\InstallRoot" Name="Path" Type="raw" Win64="yes" />
       <RegistrySearch Id="OfficeExcel2013InstallPath32" Root="HKLM" Key="SOFTWARE\Microsoft\Office\15.0\Excel\InstallRoot" Name="Path" Type="raw" Win64="no" />
     </Property>
+    <Property Id="EXCEL2016INSTALLPATH" Secure="yes">
+      <RegistrySearch Id="OfficeExcel2016InstallPath64" Root="HKLM" Key="SOFTWARE\Microsoft\Office\16.0\Excel\InstallRoot" Name="Path" Type="raw" Win64="yes" />
+      <RegistrySearch Id="OfficeExcel2016InstallPath32" Root="HKLM" Key="SOFTWARE\Microsoft\Office\16.0\Excel\InstallRoot" Name="Path" Type="raw" Win64="no" />
+    </Property>
     
-    <Condition Message="This setup requires Office Excel 2007 and/or 2010 and/or 2013 (32-bit or 64-bit).">
-      <![CDATA[Installed OR EXCEL2007INSTALLPATH OR EXCEL2010INSTALLPATH OR EXCEL2013INSTALLPATH]]>
+    <Condition Message="This setup requires Office Excel 2007 and/or 2010 and/or 2013 and/or 2016 (32-bit or 64-bit).">
+      <![CDATA[Installed OR EXCEL2007INSTALLPATH OR EXCEL2010INSTALLPATH OR EXCEL2013INSTALLPATH OR EXCEL2016INSTALLPATH]]>
     </Condition>
 
     <!--command arguments to pass to .exe-->
-    <Property Id="CREATE_HKCU_OPEN_CMD" Value="/install $(var.XLL32) $(var.XLL64) $(var.OFFICEREGKEYS)" />
-    <Property Id="REMOVE_HKCU_OPEN_CMD" Value="/uninstall $(var.XLL32) $(var.XLL64) $(var.OFFICEREGKEYS)" />
+    <Property Id="CREATE_HKCU_OPEN_CMD" Value='/install "$(var.XLL32)" "$(var.XLL64)" $(var.OFFICEREGKEYS)' />
+    <Property Id="REMOVE_HKCU_OPEN_CMD" Value='/uninstall "$(var.XLL32)" "$(var.XLL64)" $(var.OFFICEREGKEYS)' />
     
     <!-- Custom Actions -->
     <Binary Id="_BinID_CustomAction" SourceFile="$(var.CADLLFULLPATH)" />


### PR DESCRIPTION
The XLL path wasn't being enclosed in quotes, so any spaces caused it to be interpreted as additional arguments to the manageOpenKey application, added quotes around this path (both 32 and 64 bit) so that it allows for spaces.

Also added the registry search for Excel 2016, however have seen some strange behaviour on my 2016 install where it (Excel 2016 installer) hasn't removed the Office 2013 registry keys.